### PR TITLE
fix(paiement): comment out validation for devis status before payment

### DIFF
--- a/src/produits/services/paiement.service.ts
+++ b/src/produits/services/paiement.service.ts
@@ -38,9 +38,9 @@ export class PaiementService {
             throw new NotFoundException('Devis non trouvé');
         }
 
-        if (devis.statut !== StatutDevis.SAUVEGARDE) {
-            throw new BadRequestException('Le devis doit être sauvegardé avant de pouvoir être payé');
-        }
+        // if (devis.statut !== StatutDevis.SAUVEGARDE) {
+        //     throw new BadRequestException('Le devis doit être sauvegardé avant de pouvoir être payé');
+        // }
 
         const referencePaiement = this.genererReferencePaiement();
 


### PR DESCRIPTION
Temporarily disable the check that requires the devis to be in the 'SAUVEGARDE' status before processing payment. This change allows for more flexibility in the payment process while further evaluation is conducted.