### PR TITLE
refactor(souscription): comment out validation for devis status

### DIFF
--- a/src/produits/services/souscription.service.ts
+++ b/src/produits/services/souscription.service.ts
@@ -55,9 +55,9 @@ export class SouscriptionService {
       throw new NotFoundException('Devis non trouvé');
     }
 
-    if (devis.statut !== StatutDevis.SAUVEGARDE) {
-      throw new BadRequestException('Le devis doit être sauvegardé avant de pouvoir être souscrit');
-    }
+    // if (devis.statut !== StatutDevis.SAUVEGARDE) {
+    //   throw new BadRequestException('Le devis doit être sauvegardé avant de pouvoir être souscrit');
+    // }
 
     //vérification si le produit nécessite des bénéficiaires
     if (devis.produit.necessite_beneficiaires) {


### PR DESCRIPTION
Temporarily disable the validation that requires the devis to be in the 'SAUVEGARDE' status before proceeding with the subscription process. This change aims to enhance flexibility in the souscription workflow.