### PR TITLE
fix(docker): restore Traefik labels for automatic domain and SSL mana…

### DIFF
--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -7,16 +7,14 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-    # Exposer le port 3000 du container sur le port 3001 de l'hôte
-    # (3000 est déjà utilisé par Dokploy)
-    ports:
-      - "127.0.0.1:3001:3000"
-    # Désactiver les labels Traefik car Nginx route directement vers le container
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.http.routers.saarflex-api.rule=Host(`api-saarflex.saarassurancesci.com`)"
-    #   - "traefik.http.routers.saarflex-api.entrypoints=web"
-    #   - "traefik.http.services.saarflex-api.loadbalancer.server.port=3000"
+    # Labels Traefik pour que Dokploy gère le domaine et SSL automatiquement
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.saarflex-api.rule=Host(`api-saarflex.saarassurancesci.com`)"
+      - "traefik.http.routers.saarflex-api.entrypoints=websecure"
+      - "traefik.http.routers.saarflex-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.saarflex-api.tls=true"
+      - "traefik.http.services.saarflex-api.loadbalancer.server.port=3000"
     # Healthcheck pour Dokploy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]


### PR DESCRIPTION
…gement

- Reintroduced Traefik labels in docker-compose.dokploy.yml to enable Dokploy to manage domain routing and SSL certificates automatically.
- Removed previous port mapping changes to ensure proper integration with Traefik.