### PR TITLE
fix(docker): update port mapping for saarflex-api in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       target: development
     container_name: saarflex-api
     ports:
-      - "3000:3000"
+      - "3006:3000"
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
- Changed the exposed port for saarflex-api from 3000 to 3006 to avoid conflicts with other services.