### PR TITLE
refactor: Rename phpmyadmin database dependency from `saarflex-db` to…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -92,7 +92,7 @@ services:
       PMA_ARBITRARY: 1
       MYSQL_ALLOW_EMPTY_PASSWORD: 0
     depends_on:
-      saarflex-db:
+      db:
         condition: service_healthy
     networks:
       - saarflex-network


### PR DESCRIPTION
… `db` in production compose.