### PR TITLE
feat(admin): implement drag-and-drop reordering for pricing criteria

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",

--- a/src/produits/admin/controllers/criteres-admin.controller.ts
+++ b/src/produits/admin/controllers/criteres-admin.controller.ts
@@ -28,7 +28,8 @@ import {
   UpdateValeurCritereDto,
   CritereTarificationAdminDto,
   ValeurCritereDto,
-  CriteresAdminResponseDto
+  CriteresAdminResponseDto,
+  ReorderCriteresDto
 } from '../../dto/critere-tarification-admin.dto';
 import { JwtAuthGuard } from '../../../users/jwt/jwt-auth.guard';
 import { AdminGuard } from '../../../users/guards/admin.guard';
@@ -80,6 +81,26 @@ export class CriteresAdminController {
             status: 'success',
             message: 'Critère de tarification créé avec succès',
             data: critere
+        };
+    }
+
+    @Post('reorder')
+    @ApiOperation({ 
+        summary: 'Réorganiser l\'ordre des critères',
+        description: 'Endpoint réservé aux administrateurs pour mettre à jour l\'ordre d\'affichage de plusieurs critères'
+    })
+    @ApiBody({ type: ReorderCriteresDto })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Ordre mis à jour avec succès'
+    })
+    async reorder(
+        @Body() reorderDto: ReorderCriteresDto
+    ): Promise<{ status: string; message: string }> {
+        const result = await this.criteresAdminService.reorder(reorderDto);
+        return {
+            status: 'success',
+            message: result.message
         };
     }
 

--- a/src/produits/admin/services/criteres-admin.service.ts
+++ b/src/produits/admin/services/criteres-admin.service.ts
@@ -12,7 +12,8 @@ import {
     UpdateValeurCritereDto,
     CritereTarificationAdminDto,
     ValeurCritereDto,
-    CriteresAdminResponseDto
+    CriteresAdminResponseDto,
+    ReorderCriteresDto
 } from '../../dto/critere-tarification-admin.dto';
 
 @Injectable()
@@ -234,6 +235,16 @@ export class CriteresAdminService {
 
         return {
             message: `Critère "${critere.nom}" supprimé avec succès`
+        };
+    }
+
+    async reorder(reorderDto: ReorderCriteresDto): Promise<{ message: string }> {
+        for (const item of reorderDto.criteres) {
+            await this.critereRepository.update(item.id, { ordre: item.ordre });
+        }
+
+        return {
+            message: 'Ordre des critères mis à jour avec succès'
         };
     }
 

--- a/src/produits/dto/critere-tarification-admin.dto.ts
+++ b/src/produits/dto/critere-tarification-admin.dto.ts
@@ -364,3 +364,22 @@ export class CriteresAdminResponseDto {
   @ApiProperty({ description: 'Nombre total de pages' })
   total_pages: number;
 }
+
+export class CritereReorderItemDto {
+  @ApiProperty({ description: 'ID du critère', example: '123e4567-e89b-12d3-a456-426614174000' })
+  @IsUUID()
+  id: string;
+
+  @ApiProperty({ description: 'Nouvel ordre', example: 1 })
+  @IsInt()
+  @Min(1)
+  ordre: number;
+}
+
+export class ReorderCriteresDto {
+  @ApiProperty({ type: [CritereReorderItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CritereReorderItemDto)
+  criteres: CritereReorderItemDto[];
+}

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2069,6 +2069,37 @@
         ]
       }
     },
+    "/admin/criteres/reorder": {
+      "post": {
+        "description": "Endpoint réservé aux administrateurs pour mettre à jour l'ordre d'affichage de plusieurs critères",
+        "operationId": "CriteresAdminController_reorder",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderCriteresDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ordre mis à jour avec succès"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Réorganiser l'ordre des critères",
+        "tags": [
+          "Administration - Critères de Tarification"
+        ]
+      }
+    },
     "/admin/criteres/produit/{produitId}": {
       "get": {
         "description": "Endpoint réservé aux administrateurs pour lister tous les critères d'un produit spécifique",
@@ -8461,6 +8492,39 @@
           "created_at",
           "valeurs",
           "nombre_valeurs"
+        ]
+      },
+      "CritereReorderItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID du critère",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "ordre": {
+            "type": "number",
+            "description": "Nouvel ordre",
+            "example": 1
+          }
+        },
+        "required": [
+          "id",
+          "ordre"
+        ]
+      },
+      "ReorderCriteresDto": {
+        "type": "object",
+        "properties": {
+          "criteres": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CritereReorderItemDto"
+            }
+          }
+        },
+        "required": [
+          "criteres"
         ]
       },
       "CriteresAdminResponseDto": {


### PR DESCRIPTION
- add bulk reorder endpoint to API (controller, service, and DTOs)
- integrate @hello-pangea/dnd into the backoffice criteria tab
- update repository and domain interfaces to support reordering
- add visual drag handle and smooth animations to criteria cards
- ensure order consistency between front-end and back-end